### PR TITLE
feat: CRA-2903 added step for determining additional maven arguments …

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 * _save-cache_ - If cache should be saved after maven run
 * _jvm-options_ - Maven Java virtual machine settings like memory configuration
     * if missing JVM **-Xmx** parameter then action automatically calculate maximally available memory for maven process
+* _build-modules_ - Comma separated list of submodules which should be build (e.g. only changed modules), e.g: submodule,submodule/pom.xml
+  * using this input parameter will include maven argument _--also-make_, not using it include _--also-make-dependents_
 
 # License Summary
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@
 * _save-cache_ - If cache should be saved after maven run
 * _jvm-options_ - Maven Java virtual machine settings like memory configuration
     * if missing JVM **-Xmx** parameter then action automatically calculate maximally available memory for maven process
-* _build-modules_ - Comma separated list of submodules which should be build (e.g. only changed modules), e.g: submodule,submodule/pom.xml
-  * using this input parameter will include maven argument _--also-make_, not using it include _--also-make-dependents_
+* _build-dependant-modules_ - Use [true] for argument _--also-make-dependents_, [false] for argument _--also-make_
 
 # License Summary
 

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,15 @@ runs:
         fi
         echo "MAVEN_OPTS=$MAVEN_OPTS" >> $GITHUB_ENV
 
+    - name: Prepare maven arguments
+      shell: bash
+      run: |
+        if [[ ${{ inputs.build-modules }} != '' ]]; then
+          echo "ADDITIONAL_MAVEN_ARGUMENTS=--also-make" >> $GITHUB_ENV
+        else
+          echo "ADDITIONAL_MAVEN_ARGUMENTS=--also-make-dependents" >> $GITHUB_ENV
+        fi
+
     - name: Run maven command
       shell: bash
       run: |
@@ -62,7 +71,7 @@ runs:
           ${{ inputs.parameters }} \
           -Duser.timezone="Europe/Amsterdam" \
           -DuseGitHub=true \
-          --also-make-dependents \
+          ${{ env.ADDITIONAL_MAVEN_ARGUMENTS }} \
           --projects "${{ inputs.build-modules }}" \
           --threads ${{ inputs.threads }} \
           --update-snapshots \

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: "Comma separated list of submodules which should be build (e.g. only changed modules), e.g: submodule,submodule/pom.xml"
     required: false
     default: ""
+  build-dependant-modules:
+    description: "Use [true] for argument _--also-make-dependents_, [false] for argument _--also-make_"
+    required: false
+    default: "true"
   jvm-options:
     description: "Maven Java virtual machine options"
     required: false
@@ -56,11 +60,12 @@ runs:
 
     - name: Prepare maven arguments
       shell: bash
+      id: prepare_maven_arguments
       run: |
-        if [[ ${{ inputs.build-modules }} != '' ]]; then
-          echo "ADDITIONAL_MAVEN_ARGUMENTS=--also-make" >> $GITHUB_ENV
+        if [[ ${{ inputs.build-dependant-modules }} == 'true' ]]; then
+          echo "ADDITIONAL_MAVEN_ARGUMENTS=--also-make-dependents" >> GITHUB_OUTPUT
         else
-          echo "ADDITIONAL_MAVEN_ARGUMENTS=--also-make-dependents" >> $GITHUB_ENV
+          echo "ADDITIONAL_MAVEN_ARGUMENTS=--also-make" >> GITHUB_OUTPUT
         fi
 
     - name: Run maven command
@@ -71,7 +76,7 @@ runs:
           ${{ inputs.parameters }} \
           -Duser.timezone="Europe/Amsterdam" \
           -DuseGitHub=true \
-          ${{ env.ADDITIONAL_MAVEN_ARGUMENTS }} \
+          ${{ steps.prepare_maven_arguments.outputs.ADDITIONAL_MAVEN_ARGUMENTS }} \
           --projects "${{ inputs.build-modules }}" \
           --threads ${{ inputs.threads }} \
           --update-snapshots \


### PR DESCRIPTION
My use case is running build only for a specific module, but also include all modules from project, this module depends on. The normal build doesn't change, as it doesn't specify any module, so it keeps the option to build dependant modules.